### PR TITLE
Allow '-f -' to denote stdin

### DIFF
--- a/dnseval.py
+++ b/dnseval.py
@@ -256,8 +256,13 @@ def main():
 
     try:
         if fromfile:
-            with open(inputfilename, 'rt') as flist:
-                f = flist.read().splitlines()
+            if inputfilename == '-':
+                # read from stdin
+                with sys.stdin as flist:
+                    f = flist.read().splitlines()
+            else:
+                with open(inputfilename, 'rt') as flist:
+                    f = flist.read().splitlines()
         else:
             f = resolvers
         if len(f) == 0:


### PR DESCRIPTION
Added an option to make dnseval more 'unixy' and accept stdin input.

Now you can do, for example, `host -t ns uk | cut -d ' ' -f 4 | ./dnseval.py -c 3  -f - uk.` and evaluate a whole set of nameservers.