### PR TITLE
Fix incorrect double-dash flag to enable "cache-miss" for dnseval

### DIFF
--- a/dnseval.py
+++ b/dnseval.py
@@ -102,7 +102,7 @@ def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hf:c:t:w:S:TevCmXHDj:",
                                    ["help", "file=", "count=", "type=", "wait=", "json=", "tcp", "edns", "verbose",
-                                    "color", "force-miss", "srcip=", "tls", "doh", "dnssec"])
+                                    "color", "cache-miss", "srcip=", "tls", "doh", "dnssec"])
     except getopt.GetoptError as err:
         print(err)
         usage()


### PR DESCRIPTION
Was looking at the code and noticed that the configuration for the double-dash flag for forcing cache misses was inconsitent with the --help output.

--help outputs

```
  -m  --cache-miss  Force cache miss measurement by prepending a random hostname
```

so I assume that there is a uncompleted change that might cause these differances.