### PR TITLE
Add --miss-cache flag to dnsping

### DIFF
--- a/dnsping.py
+++ b/dnsping.py
@@ -222,11 +222,11 @@ def main():
 
         if use_edns:
             query = dns.message.make_query(fqdn, rdatatype, dns.rdataclass.IN,
-                                        use_edns=True, want_dnssec=want_dnssec,
-                                        ednsflags=dns.flags.edns_from_text('DO'), payload=8192)
+                                           use_edns=True, want_dnssec=want_dnssec,
+                                           ednsflags=dns.flags.edns_from_text('DO'), payload=8192)
         else:
             query = dns.message.make_query(fqdn, rdatatype, dns.rdataclass.IN,
-                                        use_edns=False, want_dnssec=want_dnssec)
+                                           use_edns=False, want_dnssec=want_dnssec)
 
         try:
             stime = time.perf_counter()


### PR DESCRIPTION
I felt like it would be helpful to have a `miss-cache` option for the `dnsping` just like for `dnseval`. 

This PR adds an option using the exact same syntax and mechanics as the same option for `dnseval`, to offer more flexibility to dnsdiag.