### PR TITLE
* Improvements on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM python:3.8.2
+FROM python:3.8-alpine
 
 WORKDIR /dnsdiag
+
+ENV PATH "$PATH:/dnsdiag"
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ From time to time, binary packages will be released for Windows, Mac OS X and Li
 If you don't want to install dnsdiags on your local machine, you may use the docker image and run programs in a container. For example:
 
 ```
-docker run -it --rm farrokhi/dnsdiag ./dnsping.py
+docker run --network host -it --rm farrokhi/dnsdiag dnsping.py
 ```
 
 # dnsping


### PR DESCRIPTION
* Change image to python:3.8-alpine targeting a smaller image (50mb now)
* Added /dnsdiag to path, allowing path removal from execution
* Change on README to reflect path change and recommending network mode
  as host, since it will reflect a better scenario from host.

P.s: Thanks @facebook for leading me to this repo while you had a [massive DNS failure](https://wccftech.com/facebook-instagram-whatsapp-and-workplace-go-down-in-massive-outage/).