### PR TITLE
Change default behavior of --edns to disabled by default (Fixes #97)

### DIFF
--- a/dnseval.py
+++ b/dnseval.py
@@ -63,8 +63,8 @@ usage: %s [-ehmvCTXH] [-f server-list] [-j output.json] [-c count] [-t type] [-p
   -H  --doh         Use HTTPS as transport protols (DoH)
   -p  --port        DNS server port number (default: 53 for TCP/UDP and 853 for TLS)
   -S  --srcip       Query source IP address
-  -e  --edns        Disable EDNS0 (default: Enabled)
-  -D  --dnssec      Enable 'DNSSEC desired' flag in requests.
+  -e  --edns        Enable EDNS0
+  -D  --dnssec      Enable 'DNSSEC desired' (DO flag) in requests
   -C  --color       Print colorful output
   -v  --verbose     Print actual dns response
 """ % (__progname__, __version__, __progname__))
@@ -92,7 +92,7 @@ def main():
     inputfilename = None
     fromfile = False
     json_output = False
-    use_edns = True
+    use_edns = False
     want_dnssec = False
     force_miss = False
     verbose = False
@@ -134,9 +134,10 @@ def main():
             json_output = True
             json_filename = a
         elif o in ("-e", "--edns"):
-            use_edns = False
+            use_edns = True
         elif o in ("-D", "--dnssec"):
             want_dnssec = True
+            use_edns = True  # implied
         elif o in ("-C", "--color"):
             color_mode = True
         elif o in ("-v", "--verbose"):

--- a/dnsping.py
+++ b/dnsping.py
@@ -70,7 +70,7 @@ usage: %s [-46DeFhqTvX] [-i interval] [-s server] [-p port] [-P port] [-S addres
   -w  --wait        Maximum wait time for a reply (default: 2 seconds)
   -i  --interval    Time between each request (default: 1 seconds)
   -t  --type        DNS request record type (default: A)
-  -e  --edns        Disable EDNS0 (default: Enabled)
+  -e  --edns        Enable EDNS0 and set
   -D  --dnssec      Enable 'DNSSEC desired' flag in requests. Implies EDNS.
   -F  --flags       Display response flags
 """ % (__progname__, __version__, __progname__))
@@ -125,7 +125,7 @@ def main():
     src_port = 0
     src_ip = None
     proto = PROTO_UDP
-    use_edns = True
+    use_edns = False
     want_dnssec = False
     force_miss = False
     request_flags = dns.flags.from_text('RD')
@@ -180,11 +180,12 @@ def main():
         elif o in ("-6", "--ipv6"):
             af = socket.AF_INET6
         elif o in ("-e", "--edns"):
-            use_edns = False
+            use_edns = True
         elif o in ("-r", "--norecurse"):
             request_flags = dns.flags.from_text('')
         elif o in ("-D", "--dnssec"):
             want_dnssec = True
+            use_edns = True  # implied
         elif o in ("-F", "--flags"):
             show_flags = True
         elif o in ("-p", "--port"):
@@ -226,11 +227,10 @@ def main():
 
         if use_edns:
             query = dns.message.make_query(fqdn, rdatatype, dns.rdataclass.IN, flags=request_flags,
-                                           use_edns=True, want_dnssec=want_dnssec,
-                                           ednsflags=dns.flags.EDNSFlag.DO, payload=8192)
+                                           use_edns=True, want_dnssec=want_dnssec, payload=8192)
         else:
             query = dns.message.make_query(fqdn, rdatatype, dns.rdataclass.IN, flags=request_flags,
-                                           use_edns=False, want_dnssec=want_dnssec)
+                                           use_edns=False, want_dnssec=False)
 
         try:
             stime = time.perf_counter()

--- a/dnstraceroute.py
+++ b/dnstraceroute.py
@@ -72,7 +72,7 @@ usage: %s [-aeqhCx] [-s server] [-p port] [-c count] [-t type] [-w wait]  hostna
   -w  --wait      Maximum wait time for a reply (default: 2)
   -t  --type      DNS request record type (default: A)
   -C  --color     Print colorful output
-  -e  --edns      Disable EDNS0 (Default: Enabled)
+  -e  --edns      Enable EDNS0 (Default: Disabled)
 """ % (__progname__, __version__, __progname__))
     sys.exit()
 
@@ -110,7 +110,7 @@ def expert_report(trace_path, color_mode):
     print(" %s[*]%s No expert hint available for this trace" % (color.G, color.N))
 
 
-def ping(qname, server, rdtype, proto, port, ttl, timeout, src_ip, use_edns=False):
+def ping(qname, server, rdtype, proto, port, ttl, timeout, src_ip, use_edns):
     reached = False
     resp_time = None
 
@@ -151,7 +151,7 @@ def main():
     as_lookup = False
     expert_mode = False
     should_resolve = True
-    use_edns = True
+    use_edns = False
     color_mode = False
 
     args = None
@@ -197,7 +197,7 @@ def main():
         elif o in ("-a", "--asn"):
             as_lookup = True
         elif o in ("-e", "--edns"):
-            use_edns = False
+            use_edns = True
         else:
             usage()
 

--- a/util/dns.py
+++ b/util/dns.py
@@ -105,10 +105,9 @@ def ping(qname, server, dst_port, rdtype, timeout, count, proto, src_ip, use_edn
             fqdn = qname
 
         if use_edns:
-            query = dns.message.make_query(fqdn, rdtype, dns.rdataclass.IN, use_edns, want_dnssec,
-                                           ednsflags=dns.flags.edns_from_text('DO'), payload=8192)
+            query = dns.message.make_query(fqdn, rdtype, dns.rdataclass.IN, use_edns, want_dnssec, payload=8192)
         else:
-            query = dns.message.make_query(fqdn, rdtype, dns.rdataclass.IN, use_edns, want_dnssec)
+            query = dns.message.make_query(fqdn, rdtype, dns.rdataclass.IN, use_edns=False, want_dnssec=False)
 
         try:
             if proto is PROTO_UDP:


### PR DESCRIPTION
While here, improve logic of EDNS0 and DNNSEC bit setting, for better readability. When asking for DNSSEC by setting DO, it enables EDNS0 by default.