### PR TITLE
Weaken cryptography requirement to >=42

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dnspython>=2.6.1
 cymruwhois>=1.6
 httpx>=0.27.0
-cryptography>=42.0.7
+cryptography>=42
 h2>=4.1.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     scripts=["dnseval.py", "dnsping.py", "dnstraceroute.py"],
-    install_requires=['dnspython>=2.6.1', 'cymruwhois>=1.6', 'httpx>=0.27.0', 'cryptography>=42.0.7', 'h2>=4.1.0'],
+    install_requires=['dnspython>=2.6.1', 'cymruwhois>=1.6', 'httpx>=0.27.0', 'cryptography>=42', 'h2>=4.1.0'],
 
     classifiers=[
         "Topic :: System :: Networking",


### PR DESCRIPTION
dnspython's `dnssec` extra only needs cryptography 42, not 42.0.7, so it seems unnecessary to depend on a newer patch release.  (I noticed this because Debian currently has 42.0.5, and the changes between 42.0.5 and 42.0.7 seem insignificant for DNSSEC validation.)