### PR TITLE
Improve some type annotations

### DIFF
--- a/dnsdiag/whois.py
+++ b/dnsdiag/whois.py
@@ -26,20 +26,21 @@
 
 import pickle
 import time
+from typing import Optional, Tuple
 
 import cymruwhois
 
 WHOIS_CACHE_FILE = 'whois.cache'
 
 
-def asn_lookup(ip, whois_cache) -> (str, dict):
+def asn_lookup(ip: str, whois_cache: dict) -> Tuple[Optional[Tuple[cymruwhois.record, cymruwhois.asrecord]], dict]:
     """
     Look up an ASN given teh IP address from cache. If not in cache, lookup from a whois server and update the cache
-    :param ip: IP Address (str)
-    :param whois_cache: whois data cache (dict)
-    :return: AS Number (str), Updated whois cache (dict)
+    :param ip: IP Address
+    :param whois_cache: whois data cache
+    :return: AS Number, Updated whois cache
     """
-    asn = None
+    asn: Optional[Tuple[cymruwhois.record, cymruwhois.asrecord]] = None
     try:
         currenttime = time.time()
         if ip in whois_cache:

--- a/dnstraceroute.py
+++ b/dnstraceroute.py
@@ -38,12 +38,13 @@ import dns.rdatatype
 import dns.resolver
 
 import dnsdiag.whois
+from typing import Any
 from dnsdiag.dns import PROTO_UDP, PROTO_TCP, setup_signal_handler
 from dnsdiag.shared import __version__, Colors
 
 # Global Variables
 quiet = False
-whois_cache = {}
+whois_cache: dict[str, Any] = {}
 
 # Constants
 __author__ = 'Babak Farrokhi (babak@farrokhi.net)'


### PR DESCRIPTION
As I was using dnsdiag the recent days I noticed that it is written in Python so I thought let's contribute back to the nice tool!

This PR improves some typing in the codebase. With this applied if you call `mypy --ignore-missing-imports .` it will not show any errors anymore.

Once merged I can offer adding a bit more typing in code as contribution to then be able to add more static checks.