### PR TITLE
Improve some type annotations

### DIFF
--- a/dnsdiag/whois.py
+++ b/dnsdiag/whois.py
@@ -26,20 +26,21 @@
 
 import pickle
 import time
+from typing import Optional, Tuple
 
 import cymruwhois
 
 WHOIS_CACHE_FILE = 'whois.cache'
 
 
-def asn_lookup(ip, whois_cache) -> (str, dict):
+def asn_lookup(ip: str, whois_cache: dict) -> Tuple[Optional[Tuple[cymruwhois.record, cymruwhois.asrecord]], dict]:
     """
     Look up an ASN given teh IP address from cache. If not in cache, lookup from a whois server and update the cache
-    :param ip: IP Address (str)
-    :param whois_cache: whois data cache (dict)
-    :return: AS Number (str), Updated whois cache (dict)
+    :param ip: IP Address
+    :param whois_cache: whois data cache
+    :return: AS Number, Updated whois cache
     """
-    asn = None
+    asn: Optional[Tuple[cymruwhois.record, cymruwhois.asrecord]] = None
     try:
         currenttime = time.time()
         if ip in whois_cache:

--- a/dnstraceroute.py
+++ b/dnstraceroute.py
@@ -39,12 +39,13 @@ import dns.rdatatype
 import dns.resolver
 
 import dnsdiag.whois
+from typing import Any
 from dnsdiag.dns import PROTO_UDP, PROTO_TCP, PROTO_QUIC, PROTO_HTTP3, getDefaultPort
 from dnsdiag.shared import __version__, Colors
 
 # Global Variables
 quiet = False
-whois_cache = {}
+whois_cache: dict[str, Any] = {}
 shutdown = False
 
 # Constants


### PR DESCRIPTION
Follow-up on https://github.com/farrokhi/dnsdiag/pull/127 - as discussed @farrokhi via other PR

As I was using dnsdiag the recent days I noticed that it is written in Python so I thought let's contribute back to the nice tool!

This PR improves some typing in the codebase. With this applied if you call mypy --ignore-missing-imports . it will not show any errors anymore.

Before:
```
jscheffl@hp860g9:~/Workspace/dnsdiag$ mypy --ignore-missing-imports .
dnsdiag/whois.py:35: error: Syntax error in type annotation  [syntax]
dnsdiag/whois.py:35: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
dnstraceroute.py:46: error: Need type annotation for "whois_cache" (hint: "whois_cache: dict[<type>, <type>] = ...")  [var-annotated]
Found 2 errors in 2 files (checked 8 source files)
```

After:
```
jscheffl@hp860g9:~/Workspace/dnsdiag$ mypy --ignore-missing-imports .
Success: no issues found in 8 source files
```

Once merged I can offer adding a bit more typing in code as contribution to then be able to add more static checks.