### PR TITLE
Add type hints to shared DNS module and fix type syntax errors

### DIFF
--- a/TYPING_GUIDE.md
+++ b/TYPING_GUIDE.md
@@ -1,0 +1,252 @@
+# Type Hints Guide for dnsdiag
+
+## Quick Start
+
+### 1. Install mypy
+```bash
+pip install mypy
+```
+
+### 2. Run mypy
+```bash
+# Check specific files
+mypy dnsping.py dnseval.py dnstraceroute.py
+
+# Check entire project
+mypy .
+
+# Check with HTML report
+mypy . --html-report mypy-report
+```
+
+### 3. Configuration
+The `mypy.ini` file controls mypy behavior. Start lenient and gradually enable stricter checks.
+
+## Incremental Typing Strategy
+
+### Phase 1: Fix Syntax Errors (Current Priority)
+Fix existing type annotation syntax errors:
+
+```python
+# BAD - Old tuple syntax
+def asn_lookup(ip, whois_cache) -> (str, dict):
+
+# GOOD - Use Tuple from typing
+from typing import Tuple, Optional, Any
+
+def asn_lookup(ip: str, whois_cache: dict) -> Tuple[Optional[Any], dict]:
+```
+
+Add missing annotations:
+```python
+# BAD - No annotation
+whois_cache = {}
+
+# GOOD - Annotated
+whois_cache: dict[str, Any] = {}
+```
+
+### Phase 2: Add Function Signatures
+Start with public API functions:
+
+```python
+# Before
+def ping(qname, server, dst_port, rdtype, timeout, count, proto, src_ip,
+         use_edns=False, force_miss=False, want_dnssec=False, socket_ttl=None):
+
+# After
+def ping(qname: str, server: str, dst_port: int, rdtype: str,
+         timeout: float, count: int, proto: int, src_ip: Optional[str],
+         use_edns: bool = False, force_miss: bool = False,
+         want_dnssec: bool = False, socket_ttl: Optional[int] = None) -> PingResponse:
+```
+
+### Phase 3: Add Variable Annotations
+For module-level and class variables:
+
+```python
+# Before
+response_times = []
+shutdown = False
+
+# After
+response_times: list[float] = []
+shutdown: bool = False
+```
+
+### Phase 4: Enable Strict Checks
+Gradually uncomment options in `mypy.ini`:
+
+1. `check_untyped_defs = True` - Type-check function bodies
+2. `disallow_untyped_defs = True` - Require all functions have types
+3. `warn_return_any = True` - Warn when returning Any
+4. `strict = True` - Enable all strict checks
+
+## Common Patterns for dnsdiag
+
+### DNS Protocol Constants
+```python
+# Type alias for clarity
+ProtoType = int
+
+PROTO_UDP: ProtoType = 0
+PROTO_TCP: ProtoType = 1
+```
+
+### Optional Parameters
+```python
+from typing import Optional
+
+def resolve_hostname(hostname: str, af: Optional[int] = None) -> str:
+    if af is None:
+        af = socket.AF_INET
+    # ...
+```
+
+### Lists and Dicts
+```python
+# Python 3.9+
+servers: list[str] = ['8.8.8.8', '1.1.1.1']
+cache: dict[str, tuple[Any, float]] = {}
+
+# Or using typing module (works in 3.7+)
+from typing import List, Dict, Tuple, Any
+
+servers: List[str] = ['8.8.8.8', '1.1.1.1']
+cache: Dict[str, Tuple[Any, float]] = {}
+```
+
+### Return Types for Complex Functions
+```python
+from typing import Union, Optional
+from dataclasses import dataclass
+
+@dataclass
+class DNSResponse:
+    rcode: int
+    answer: Optional[list]
+    flags: int
+
+def query_dns(server: str) -> Union[DNSResponse, None]:
+    # ...
+```
+
+### Type Aliases
+```python
+from typing import TypeAlias
+
+# For readability
+IPAddress: TypeAlias = str
+Hostname: TypeAlias = str
+WhoisCache: TypeAlias = dict[str, tuple[Any, float]]
+
+def lookup(ip: IPAddress, cache: WhoisCache) -> tuple[Optional[Any], WhoisCache]:
+    # ...
+```
+
+## Handling Third-Party Libraries
+
+For libraries without type stubs (cymruwhois, dnspython):
+
+```python
+# Option 1: Use Any for their types
+from typing import Any
+
+def process_whois(result: Any) -> str:
+    return result.owner
+
+# Option 2: Create stub files (advanced)
+# Create cymruwhois.pyi with type stubs
+
+# Option 3: Ignore in mypy.ini
+[mypy-cymruwhois]
+ignore_missing_imports = True
+```
+
+## Running mypy in CI/CD
+
+### GitHub Actions Example
+```yaml
+- name: Type check with mypy
+  run: |
+    pip install mypy
+    mypy dnsping.py dnseval.py dnstraceroute.py
+```
+
+### Pre-commit Hook
+```bash
+# .git/hooks/pre-commit
+#!/bin/bash
+mypy --quiet dnsping.py dnseval.py dnstraceroute.py || exit 1
+```
+
+## Best Practices
+
+1. **Start small**: Add types to new code first
+2. **Be pragmatic**: Use `Any` when third-party types are unclear
+3. **Document intent**: Type hints serve as inline documentation
+4. **Run regularly**: Include mypy in CI/CD
+5. **Avoid over-typing**: Don't type internal implementation details unless helpful
+6. **Use # type: ignore sparingly**: Only when mypy is wrong
+
+## Common mypy Errors and Fixes
+
+### Error: "Need type annotation for X"
+```python
+# Before
+cache = {}
+
+# After
+from typing import Any
+cache: dict[str, Any] = {}
+```
+
+### Error: "Syntax error in type annotation"
+```python
+# Before
+def func() -> (str, int):
+
+# After
+from typing import Tuple
+def func() -> Tuple[str, int]:
+```
+
+### Error: "Incompatible return value type"
+```python
+# Before
+def get_port() -> int:
+    return None  # Error!
+
+# After
+from typing import Optional
+def get_port() -> Optional[int]:
+    return None  # OK
+```
+
+### Error: "Argument has incompatible type"
+```python
+# Fix by adjusting type annotations to match actual usage
+def process(data: str) -> None:  # Says str
+    pass
+
+process(123)  # Error: int is not str
+
+# Fix: Either change annotation or convert
+def process(data: str | int) -> None:  # Accept both
+    pass
+```
+
+## Tools
+
+- **mypy**: Static type checker
+- **pyright**: Alternative type checker (faster)
+- **pyre**: Facebook's type checker
+- **VSCode**: Built-in type checking with Pylance
+- **PyCharm**: Built-in type checking
+
+## Resources
+
+- [mypy documentation](https://mypy.readthedocs.io/)
+- [Python typing module](https://docs.python.org/3/library/typing.html)
+- [PEP 484](https://www.python.org/dev/peps/pep-0484/) - Type Hints
+- [Real Python typing guide](https://realpython.com/python-type-checking/)

--- a/dnsdiag/dns.py
+++ b/dnsdiag/dns.py
@@ -29,6 +29,7 @@ import random
 import socket
 import sys
 from statistics import stdev
+from typing import Optional, List, Any
 
 import httpx
 import dns.message
@@ -38,31 +39,31 @@ import dns.rdataclass
 import string
 
 # Transport protocols
-PROTO_UDP = 0
-PROTO_TCP = 1
-PROTO_TLS = 2
-PROTO_HTTPS = 3
-PROTO_QUIC = 4
-PROTO_HTTP3 = 5
+PROTO_UDP: int = 0
+PROTO_TCP: int = 1
+PROTO_TLS: int = 2
+PROTO_HTTPS: int = 3
+PROTO_QUIC: int = 4
+PROTO_HTTP3: int = 5
 
-_TTL = None
+_TTL: Optional[int] = None
 
 
 class PingResponse:
-    def __init__(self):
-        self.r_avg = 0
-        self.r_min = 0
-        self.r_max = 0
-        self.r_stddev = 0
-        self.r_lost_percent = 0
-        self.flags = 0
-        self.ttl = None
-        self.answer = None
-        self.rcode = 0
-        self.rcode_text = ''
+    def __init__(self) -> None:
+        self.r_avg: float = 0
+        self.r_min: float = 0
+        self.r_max: float = 0
+        self.r_stddev: float = 0
+        self.r_lost_percent: float = 0
+        self.flags: int = 0
+        self.ttl: Optional[int] = None
+        self.answer: Optional[Any] = None
+        self.rcode: int = 0
+        self.rcode_text: str = ''
 
 
-def proto_to_text(proto):
+def proto_to_text(proto: int) -> str:
     _proto_name = {
         PROTO_UDP: 'UDP',
         PROTO_TCP: 'TCP',
@@ -74,7 +75,7 @@ def proto_to_text(proto):
     return _proto_name[proto]
 
 
-def getDefaultPort(proto):
+def getDefaultPort(proto: int) -> int:
     _proto_port = {
         PROTO_UDP: 53,
         PROTO_TCP: 53,
@@ -87,7 +88,7 @@ def getDefaultPort(proto):
 
 
 class CustomSocket(socket.socket):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(CustomSocket, self).__init__(*args, **kwargs)
         if _TTL:
             # Set TTL/hop limit based on address family
@@ -97,13 +98,14 @@ class CustomSocket(socket.socket):
                 self.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_UNICAST_HOPS, _TTL)
 
 
-def ping(qname, server, dst_port, rdtype, timeout, count, proto, src_ip, use_edns=False, force_miss=False,
-         want_dnssec=False, socket_ttl=None):
+def ping(qname: str, server: str, dst_port: int, rdtype: str, timeout: float, count: int, proto: int,
+         src_ip: Optional[str], use_edns: bool = False, force_miss: bool = False,
+         want_dnssec: bool = False, socket_ttl: Optional[int] = None) -> PingResponse:
     retval = PingResponse()
     retval.rcode_text = "No Response"
 
-    response_times = []
-    i = 0
+    response_times: List[float] = []
+    i: int = 0
 
     if socket_ttl:
         global _TTL
@@ -202,13 +204,13 @@ def ping(qname, server, dst_port, rdtype, timeout, count, proto, src_ip, use_edn
     return retval
 
 
-def random_string(min_length=5, max_length=10):
+def random_string(min_length: int = 5, max_length: int = 10) -> str:
     char_set = string.ascii_letters + string.digits
     length = random.randint(min_length, max_length)
     return ''.join(map(lambda unused: random.choice(char_set), range(length)))
 
 
-def unsupported_feature(feature=""):
+def unsupported_feature(feature: str = "") -> None:
     print("Error: You have an unsupported version of Python interpreter dnspython library.")
     print("       Some features such as DoT and DoH are not available. You should upgrade")
     print("       the Python interpreter to at least 3.10 and reinstall dependencies.")
@@ -217,7 +219,7 @@ def unsupported_feature(feature=""):
     sys.exit(127)
 
 
-def valid_rdatatype(rtype):
+def valid_rdatatype(rtype: str) -> bool:
     # validate RR type
     try:
         _ = dns.rdatatype.from_text(rtype)
@@ -226,7 +228,7 @@ def valid_rdatatype(rtype):
     return True
 
 
-def flags_to_text(flags):
+def flags_to_text(flags: int) -> str:
     # Standard DNS flags
 
     QR = 0x8000

--- a/dnsdiag/whois.py
+++ b/dnsdiag/whois.py
@@ -26,20 +26,21 @@
 
 import pickle
 import time
+from typing import Optional, Tuple, Any
 
 import cymruwhois
 
 WHOIS_CACHE_FILE = 'whois.cache'
 
 
-def asn_lookup(ip, whois_cache) -> (str, dict):
+def asn_lookup(ip: str, whois_cache: dict) -> Tuple[Optional[Any], dict]:
     """
     Look up an ASN given teh IP address from cache. If not in cache, lookup from a whois server and update the cache
-    :param ip: IP Address (str)
-    :param whois_cache: whois data cache (dict)
-    :return: AS Number (str), Updated whois cache (dict)
+    :param ip: IP Address
+    :param whois_cache: whois data cache
+    :return: AS Number, Updated whois cache
     """
-    asn = None
+    asn: Optional[Any] = None
     try:
         currenttime = time.time()
         if ip in whois_cache:

--- a/dnstraceroute.py
+++ b/dnstraceroute.py
@@ -39,12 +39,13 @@ import dns.rdatatype
 import dns.resolver
 
 import dnsdiag.whois
+from typing import Any, Dict
 from dnsdiag.dns import PROTO_UDP, PROTO_TCP, PROTO_QUIC, PROTO_HTTP3, getDefaultPort
 from dnsdiag.shared import __version__, Colors
 
 # Global Variables
 quiet = False
-whois_cache = {}
+whois_cache: Dict[str, Any] = {}
 shutdown = False
 
 # Constants

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,43 @@
+[mypy]
+# Start with lenient settings, gradually make stricter
+
+# Python version
+python_version = 3.9
+
+# Import discovery
+mypy_path = .
+namespace_packages = True
+
+# Suppress errors from libraries without type stubs
+ignore_missing_imports = True
+
+# Incremental strictness - uncomment to enable gradually
+# disallow_untyped_defs = True        # Require all functions to have type hints
+# disallow_any_unimported = True      # Disallow Any from missing imports
+# warn_return_any = True              # Warn when returning Any from typed function
+# warn_unused_ignores = True          # Warn about unnecessary # type: ignore comments
+# strict_optional = True              # Treat Optional types strictly (already default)
+# check_untyped_defs = True           # Type-check bodies of untyped functions
+
+# Output
+show_error_codes = True
+show_column_numbers = True
+pretty = True
+
+# Per-module options
+[mypy-tests.*]
+# Be more lenient with test files
+disallow_untyped_defs = False
+ignore_errors = False
+
+[mypy-cymruwhois]
+# Third-party library without type stubs
+ignore_missing_imports = True
+
+[mypy-dns.*]
+# dnspython library
+ignore_missing_imports = True
+
+[mypy-httpx]
+# httpx library
+ignore_missing_imports = True


### PR DESCRIPTION
Add type annotations to dnsdiag/dns.py to improve type safety and enable static type checking with mypy. Fix existing type annotation syntax errors in whois.py and dnstraceroute.py.

Changes:
- Add type signatures to all functions in shared module
- Add type annotations where it made sense
- Add mypy configuration with lenient settings for gradual adoption
- Add TYPING_GUIDE.md with examples and best practices

Thanks to @jscheffl (This closes PR #132)