### PR TITLE
Add DoQ and DoH3 protocol support to dnseval

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,9 @@ list of DNS servers, allowing you to compare their response times
 simultaneously.
 
 You can use `dnseval` to evaluate response times across different transport
-protocols, including UDP (default), TCP, DoT (DNS over TLS), and DoH (DNS over
-HTTPS) by using the `--tcp`, `--tls`, and `--doh` flags, respectively.
+protocols, including UDP (default), TCP, DoT (DNS over TLS), DoH (DNS over
+HTTPS), DoQ (DNS over QUIC), and DoH3 (DNS over HTTP/3) by using the `--tcp`,
+`--tls`, `--doh`, `--quic`, and `--http3` flags, respectively.
 
 ## Protocol Support Summary
 
@@ -216,7 +217,7 @@ HTTPS) by using the `--tcp`, `--tls`, and `--doh` flags, respectively.
 |------|-----|-----|-----------|-----|-----|------|
 | `dnsping` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `dnstraceroute` | ✓ | ✓ | - | - | ✓ | ✓ |
-| `dnseval` | ✓ | ✓ | ✓ | ✓ | - | - |
+| `dnseval` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 *DoQ: DNS over QUIC, DoH3: DNS over HTTP/3*
 

--- a/tests/test_dnseval_pytest.py
+++ b/tests/test_dnseval_pytest.py
@@ -170,6 +170,20 @@ class TestProtocols:
         assert result.success, f"TLS evaluation failed: {result.error}"
         assert result.has_results
 
+    def test_quic_protocol(self, runner):
+        """Test evaluation with QUIC protocol"""
+        result = runner.run(['--quic', '-c', '2', '-f', '-', 'google.com'],
+                           stdin=b'94.140.14.14\n')
+        assert result.success, f"QUIC evaluation failed: {result.error}"
+        assert result.has_results
+
+    def test_http3_protocol(self, runner):
+        """Test evaluation with HTTP/3 protocol"""
+        result = runner.run(['--http3', '-c', '2', '-f', '-', 'google.com'],
+                           stdin=b'1.1.1.1\n')
+        assert result.success, f"HTTP/3 evaluation failed: {result.error}"
+        assert result.has_results
+
 
 class TestRecordTypes:
     """Tests for different DNS record types"""


### PR DESCRIPTION
Extend dnseval to support DNS over QUIC (DoQ) and DNS over HTTP/3 (DoH3) for feature parity with dnsping and dnstraceroute. Refactor default port handling to use getDefaultPort() function for consistency across protocols.

Changes:
- Add -Q/--quic and -3/--http3 command-line options
- Update protocol-specific port selection logic
- Add test coverage for DoQ and DoH3 protocols
- Update README.md protocol support table and documentation

Fixes #137