### PR TITLE
Fix doh http version

### DIFF
--- a/dnsdiag/dns.py
+++ b/dnsdiag/dns.py
@@ -154,6 +154,9 @@ def ping(qname: str, server: str, dst_port: int, rdtype: str, timeout: float, co
                 else:
                     unsupported_feature()
 
+        except dns.query.NoDOH:
+            print("DNS-over-HTTPS requires the httpx module. Install it with: pip install httpx", file=sys.stderr, flush=True)
+            raise
         except (httpx.ConnectTimeout, httpx.ReadTimeout,
                 httpx.ConnectError):
             raise ConnectionError('Connection failed')

--- a/dnsping.py
+++ b/dnsping.py
@@ -389,6 +389,8 @@ def main():
                         answers = dns.query.https(query, https_server, timeout=timeout, port=dst_port,
                                                   source=src_ip, source_port=src_port,
                                                   http_version=dns.query.HTTPVersion.HTTP_2)
+                    except dns.query.NoDOH:
+                        print_stderr("DNS-over-HTTPS requires the httpx module. Install it with: pip install httpx", should_die=True)
                     except httpx.ConnectError:
                         print_stderr(f"The server did not respond to DoH on port {dst_port}", should_die=True)
                 else:


### PR DESCRIPTION
- When specifying `--doh`, stick with HTTP/2 protocol and do not get fancy with automatic upgrades
- Fail gracefully in case of missing dependency
